### PR TITLE
Add requirement for GNU grep on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ git clone --recursive https://github.com/screetsec/Sudomy.git
 ```
 $ python3 -m pip install -r requirements.txt
 ```
-*Sudomy* requires [jq](https://stedolan.github.io/jq/download/) to run and parse. Information on how to download and install jq can be accessed [here](https://stedolan.github.io/jq/download/)
+*Sudomy* requires [jq](https://stedolan.github.io/jq/download/) and [GNU grep](https://www.gnu.org/software/grep/) to run and parse. Information on how to download and install jq can be accessed [here](https://stedolan.github.io/jq/download/)
 
 ```bash
 # Linux
@@ -174,8 +174,11 @@ brew cask install phantomjs
 brew install jq nmap npm parallel
 npm i -g wappalyzer wscat
 
+brew install grep
+
 # Note
 All you would need is an installation of the latest Google Chrome or Chromium 
+Set the PATH in rc file for GNU grep changes
 ```
 
 ## Running in a Docker Container

--- a/sudomy
+++ b/sudomy
@@ -329,6 +329,16 @@ for dependency in "${dependencies[@]}"; do
 	}
 done
 
+## Check GNU grep for MacOS
+if [[ "$(grep -V)" == *"BSD"* ]]; then 
+    echo "Error: require GNU grep. Aborting." >&2
+    exit 1
+fi
+
+
+
+
+
 ## Check 3rd dependencies 
 
 


### PR DESCRIPTION
Sudomy using grep tool for parsing any data from the source, but the default grep version in MacOS use BSD grep which is not compatible with Sudomy. So this changes will checking the existing grep version, if GNU grep not exist so will abort the script and mandatory to install GNU grep.