### PR TITLE
Update Dockerfile - add PATH variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 
 FROM builder
+ENV PATH "$PATH:/usr/lib/sudomy/lib/bin"
 ENV SHODAN_API="" CENSYS_API="" CENSYS_SECRET="" VIRUSTOTAL="" BINARYEDGE="" SECURITY_TRAILS="" DNSDB_API="" PASSIVE_API="" SPYSE_API="" FACEBOOK_TOKEN="" YOUR_WEBHOOK_URL=""
 RUN npm config set unsafe-perm true \
     # Install wappalyzer & wscat


### PR DESCRIPTION
Update Dockerfile - add $PATH to environment variables to fix missing packages:

```
    - Warning: require httprobe but it's is not installed.Trying to setup pkg_httprobe 
    - Warning: require httpx but it's is not installed.Trying to setup pkg_httpx 
    - Warning: require dnsprobe but it's is not installed.Trying to setup pkg_httpx 
    - Warning: require gobuster but it's is not installed.Trying to setup pkg_gobuster 
    - Warning: require webanalyze but it's is not installed.Trying to setup pkg_webanalyze 
    - Warning: require cf-check but it's is not installed.Trying to setup pkg_cf-check 
    - Warning: require gowitness but it's is not installed.Trying to setup pkg_gowitness 
    - Warning: require unfurl but it's is not installed.Trying to setup pkg_unfurl 
    - Warning: require subjack but it's is not installed.Trying to setup pkg_subjack
```