### PR TITLE
Spelling fix in sudomy.conf

### DIFF
--- a/sudomy.conf
+++ b/sudomy.conf
@@ -136,7 +136,7 @@ FINAL_PINGSWEEP=Live_hosts_pingsweep.txt
 FINAL_SUBDOMAIN_REV_ALL=Subdomain_Resolver.txt
 
 
-## USE SPESIFIC SOURCE
+## USE SPECIFIC SOURCE
 SOURCE=false
 verbose=false
 


### PR DESCRIPTION
Fixed 'specific' being spelled wrong in sudomy.conf