### PR TITLE
Added r to handle regex warning

### DIFF
--- a/lib/resolver/exec_resolver.py
+++ b/lib/resolver/exec_resolver.py
@@ -20,7 +20,7 @@ BOLD="\033[01;01m"    		# Highlight
 WHITE="\033[1;37m"		# BOLD
 YELLOW="\033[1;33m"		# Warning
 PADDING="  "
-ip_regex = "^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$"
+ip_regex = r"^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$"
 
 def print_live(text):
     print(f"{PADDING}{YELLOW}{PADDING}⍥{PADDING}{RESET}[{GREEN}RESOLVER{RESET}]\t{text}")


### PR DESCRIPTION
This pull request fixes a SyntaxWarning in `exec_resolver.py` by adding a raw string prefix (`r`) to the regex pattern for IP addresses. This change ensures that the backslashes in the regex are interpreted correctly, preventing any warnings or errors.

Changes made:
- Updated the `ip_regex` variable to use a raw string: `ip_regex = r"^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$"`

These changes have been tested locally and the script runs without errors or warnings.